### PR TITLE
Add warning before restoring

### DIFF
--- a/arm9/source/arm9.c
+++ b/arm9/source/arm9.c
@@ -152,6 +152,34 @@ int dumpNAND(nocash_footer_t *footer){
 int restoreNAND(nocash_footer_t *footer){
 	consoleClear();
 
+	printf("\x1B[41mWARNING!\x1B[47m Even with the safety\n");
+	printf("measures taken here, writing to\n");
+	printf("NAND is very dangerous and most\n");
+	printf("issues are not helped by a NAND\n");
+	printf("NAND backup restore. Only use\n");
+	printf("if you know what you're doing.\n\n");
+	printf("Press X + Y to begin restore\n");
+	printf("Press B to cancel\n");
+
+	u16 held = 0;
+	while(1) {
+		do {
+			swiWaitForVBlank();
+			scanKeys();
+			held = keysHeld();
+		} while(!(held & (KEY_X | KEY_Y | KEY_B)));
+
+		if((held & (KEY_X | KEY_Y)) == (KEY_X | KEY_Y)) {
+			consoleClear();
+			break;
+		} else if(held & KEY_B) {
+			consoleClear();
+			iprintf("Press Y to begin NAND restore\n");
+			iprintf("Press A to begin NAND dump\nPress START to exit\n\n");
+			return -1;
+		}
+	}
+
 	u32 rwTotal=nand_GetSize()*0x200; //240MB or 245.5MB
 	printf("NAND size: %.2fMB\n", (float)rwTotal/(float)0x100000);
 

--- a/arm9/source/arm9.c
+++ b/arm9/source/arm9.c
@@ -155,9 +155,10 @@ int restoreNAND(nocash_footer_t *footer){
 	printf("\x1B[41mWARNING!\x1B[47m Even with the safety\n");
 	printf("measures taken here, writing to\n");
 	printf("NAND is very dangerous and most\n");
-	printf("issues are not helped by a NAND\n");
-	printf("backup restore. Only continue\n");
-	printf("if you know what you're doing.\n\n");
+	printf("issues are not helped by\n");
+	printf("restoring a NAND backup.\n\n");
+	printf("Only continue if you're certain\n");
+	printf("this will fix your problem.\n\n");
 	printf("Press X + Y to begin restore\n");
 	printf("Press B to cancel\n");
 

--- a/arm9/source/arm9.c
+++ b/arm9/source/arm9.c
@@ -156,7 +156,7 @@ int restoreNAND(nocash_footer_t *footer){
 	printf("measures taken here, writing to\n");
 	printf("NAND is very dangerous and most\n");
 	printf("issues are not helped by a NAND\n");
-	printf("NAND backup restore. Only use\n");
+	printf("backup restore. Only continue\n");
 	printf("if you know what you're doing.\n\n");
 	printf("Press X + Y to begin restore\n");
 	printf("Press B to cancel\n");


### PR DESCRIPTION
This simply adds the warning
```
WARNING! Even with the safety
measures taken here, writing to
NAND is very dangerous and most
issues are not helped by
restoring a NAND backup.

Only continue if you're certain
this will fix your problem.

Press X + Y to begin restore
Press B to cancel
```
(with `WARNING!` in red)

and requiring you to press X and Y together to confirm the restore before it starts. While this does seem like its much safer than any other NAND writing before, I still think it's good to provide ample warning before it starts.

I put "most issues will not be helped by a NAND restore" as most people who want to uninstall unlaunch and probably most people who want to use this will probably be simply having a hiya, TWiLight, nds-bootstrap, etc error that is in no way related to the NAND so I wanted to try make it clear that this is not the solution to that.

Suggestions to improve the warning are welcome if anyone has better ideas.